### PR TITLE
add http2 for insecure port

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	"github.com/imdario/mergo"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/canary"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/http2insecureport"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxyssl"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/sslcipher"
@@ -113,6 +114,7 @@ type Ingress struct {
 	InfluxDB           influxdb.Config
 	ModSecurity        modsecurity.Config
 	Mirror             mirror.Config
+	HTTP2InsecurePort  bool
 }
 
 // Extractor defines the annotation parsers to be used in the extraction of annotations
@@ -162,6 +164,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"BackendProtocol":      backendprotocol.NewParser(cfg),
 			"ModSecurity":          modsecurity.NewParser(cfg),
 			"Mirror":               mirror.NewParser(cfg),
+			"HTTP2InsecurePort":    http2insecureport.NewParser(cfg),
 		},
 	}
 }

--- a/internal/ingress/annotations/http2insecureport/main.go
+++ b/internal/ingress/annotations/http2insecureport/main.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http2insecureport
+
+import (
+	networking "k8s.io/api/networking/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type http2InsecurePort struct {
+}
+
+// NewParser creates a new default backend annotation parser
+func NewParser(_ resolver.Resolver) parser.IngressAnnotation {
+	return http2InsecurePort{}
+}
+
+// Parse parses the annotations contained in the ingress to use
+// a custom default backend
+func (h http2InsecurePort) Parse(ing *networking.Ingress) (interface{}, error) {
+	return parser.GetBoolAnnotation("http2-insecure-port", ing)
+}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1051,8 +1051,9 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				Locations: []*ingress.Location{
 					loc,
 				},
-				SSLPassthrough: anns.SSLPassthrough,
-				SSLCiphers:     anns.SSLCiphers,
+				SSLPassthrough:    anns.SSLPassthrough,
+				SSLCiphers:        anns.SSLCiphers,
+				HTTP2InsecurePort: anns.HTTP2InsecurePort,
 			}
 		}
 	}

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -202,6 +202,9 @@ type Server struct {
 	SSLCiphers string `json:"sslCiphers,omitempty"`
 	// AuthTLSError contains the reason why the access to a server should be denied
 	AuthTLSError string `json:"authTLSError,omitempty"`
+	// Whether use HTTP2 for default listening port
+	// +optinal
+	HTTP2InsecurePort bool `json:"http2InsecurePort,omitempty"`
 }
 
 // Location describes an URI inside a server.

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -518,7 +518,7 @@ http {
     server {
         server_name {{ $redirect.From }};
 
-        {{ buildHTTPListener  $all $redirect.From }}
+        {{ buildHTTPListener  $all $redirect.From false }}
         {{ buildHTTPSListener $all $redirect.From }}
 
         ssl_certificate_by_lua_block {
@@ -824,7 +824,7 @@ stream {
         {{ $all := .First }}
         {{ $server := .Second }}
 
-        {{ buildHTTPListener  $all $server.Hostname }}
+        {{ buildHTTPListener  $all $server.Hostname $server.HTTP2InsecurePort }}
         {{ buildHTTPSListener $all $server.Hostname }}
 
         set $proxy_upstream_name "-";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

The python grpc client does not support "InsecureSkipVerify" option according to https://github.com/grpc/grpc/issues/10701. When we are trying to connect to ingress using grpc "insecure_channel", we will end up in connection issue like 'Trying to connect an http1.x server'.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR add an optional annotation for ingress, and if it is set to true, controller will render an extra 'http2' after 'listen 80' directive in nginx config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
